### PR TITLE
bump minor rev.

### DIFF
--- a/lib/check_disk.rb
+++ b/lib/check_disk.rb
@@ -1,4 +1,4 @@
 # CheckDisk Version
 module CheckDisk
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
we improved testing on bin/check_disk
we made bin/check_disk perform both block and inode checks by default. If you want to check only inodes, use -i, and similarly for blocks.
