### PR TITLE
exit critical first.

### DIFF
--- a/bin/check_disk.rb
+++ b/bin/check_disk.rb
@@ -60,8 +60,8 @@ module CheckDisk
 
     def common_check(disk)
       message(disk.message)
-      warning if disk.warning?
       critical if disk.critical?
+      warning if disk.warning?
     end
 
     # Adds a `-p` or `--path` option to our CLI.

--- a/lib/check_disk.rb
+++ b/lib/check_disk.rb
@@ -1,4 +1,4 @@
 # CheckDisk Version
 module CheckDisk
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
A disk that is critical, will also be a disk that is warning.

A disk that is warning, is not a disk that is critical.

We could guard warning with something more than `if disk.warning?`; maybe tack a `&& ! disk.critical?`, but flipping the order of these should also achieve the same without extra complexity.